### PR TITLE
chore: update mermaid version to v10.9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN curl -S -s -o ${TMPDIR}/umlet.zip https://www.umlet.com/download/umlet_${uml
 # 'Node.js' packages
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Install mermaid-cli - @see: https://github.com/mermaid-js/mermaid-cli
-ARG mermaid_version="10.0.2"
+ARG mermaid_version="10.9.1"
 # Install mscgenjs-cli - @see: https://github.com/mscgenjs/mscgenjs-cli
 ARG mscgen_version="6.0.0"
 # Install bpmn-js-cmd - @see: https://github.com/gtudan/bpmn-js-cmd


### PR DESCRIPTION
Hey pal,

just got some errors saying
```
Error: Evaluation failed: Error: Diagram error not found.
    at pptr://__puppeteer_evaluation_script__:45:17
    at ExecutionContext._ExecutionContext_evaluate (file:///usr/local/share/.config/yarn/global/node_modules/@mermaid-js/mermaid-cli/node_modules/puppeteer-core/lib/esm/puppeteer/common/ExecutionContext.js:254:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async ExecutionContext.evaluate (file:///usr/local/share/.config/yarn/global/node_modules/@mermaid-js/mermaid-cli/node_modules/puppeteer-core/lib/esm/puppeteer/common/ExecutionContext.js:143:16)
    at async CDPJSHandle.evaluate (file:///usr/local/share/.config/yarn/global/node_modules/@mermaid-js/mermaid-cli/node_modules/puppeteer-core/lib/esm/puppeteer/common/JSHandle.js:56:16)
    at async CDPElementHandle.$eval (file:///usr/local/share/.config/yarn/global/node_modules/@mermaid-js/mermaid-cli/node_modules/puppeteer-core/lib/esm/puppeteer/common/ElementHandle.js:86:24)
    at async renderMermaid (file:///usr/local/share/.config/yarn/global/node_modules/@mermaid-js/mermaid-cli/src/index.js:241:22)
    at async parseMMD (file:///usr/local/share/.config/yarn/global/node_modules/@mermaid-js/mermaid-cli/src/index.js:213:20)
    at async run (file:///usr/local/share/.config/yarn/global/node_modules/@mermaid-js/mermaid-cli/src/index.js:508:20)
    at async cli (file:///usr/local/share/.config/yarn/global/node_modules/@mermaid-js/mermaid-cli/src/index.js:179:3)
```
when I executed asciidoctor with your image to convert mermaid diagrams. 

I came to the conclusion that this is maybe [this bug](https://github.com/mermaid-js/mermaid/issues/4140), which might have been resolved in a newer version.

Thank you!